### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/Lib/PHPGangsta/GoogleAuthenticator.php
+++ b/Lib/PHPGangsta/GoogleAuthenticator.php
@@ -34,8 +34,6 @@ class GoogleAuthenticator
         $rnd = false;
         if (function_exists('random_bytes')) {
             $rnd = random_bytes($secretLength);
-        } elseif (function_exists('mcrypt_create_iv')) {
-            $rnd = mcrypt_create_iv($secretLength, MCRYPT_DEV_URANDOM);
         } elseif (function_exists('openssl_random_pseudo_bytes')) {
             $rnd = openssl_random_pseudo_bytes($secretLength, $cryptoStrong);
             if (!$cryptoStrong) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "juashyam/authenticator",
     "description": "Magento 2 Backend 2FA implementation",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0",
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.0.0|~8.1.0",
         "magento/framework": "^100.1.0|101.0.*|^102.0.0"
     },
     "type": "magento2-module",


### PR DESCRIPTION
Remove mcrypt references completely - it has been removed in PHP 7.2. 

This is the only blocker for PHP 8.1 compatibility;

```
vendor/bin/phpcs -p vendor/juashyam/authenticator --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.1
........E. 10 / 10 (100%)



FILE: ...or/juashyam/authenticator/Lib/PHPGangsta/GoogleAuthenticator.php
----------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 1 LINE
----------------------------------------------------------------------
 38 | ERROR | Function mcrypt_create_iv() is deprecated since PHP 7.1
    |       | and removed since PHP 7.2; Use random_bytes() or
    |       | OpenSSL instead
 38 | ERROR | Extension 'mcrypt' is deprecated since PHP 7.1 and
    |       | removed since PHP 7.2; Use openssl (preferred) or
    |       | pecl/mcrypt once available instead
 38 | ERROR | The constant "MCRYPT_DEV_URANDOM" is deprecated since
    |       | PHP 7.1 and removed since PHP 7.2
----------------------------------------------------------------------

Time: 275ms; Memory: 12MB

```